### PR TITLE
Misc fixes

### DIFF
--- a/BH/D2Ptrs.h
+++ b/BH/D2Ptrs.h
@@ -77,7 +77,7 @@
 		f##Asm_##dll##_##name## = Patch::GetDllOffset(dll, address); \
 		} \
 		return &##f##Asm_##dll##_##name; \
-	} 
+	}
 
 #define VARPTR(dll, name, type, ...) \
 	type** Var_##dll##_##name##(VOID) \
@@ -90,7 +90,7 @@
 		f##Var_##dll##_##name## = Patch::GetDllOffset(dll, address); \
 		} \
 		return (type**)&##f##Var_##dll##_##name; \
-	} 
+	}
 
 #else
 #define FUNCPTR(dll, name, callingret, args, ...) extern callingret dll##_##name##args;
@@ -185,7 +185,7 @@ VARPTR(D2CLIENT, MouseOffsetX, int, 0x119960, 0x106844)
 VARPTR(D2CLIENT, AutomapOn, DWORD, 0xFADA8, 0x11C8B8)
 VARPTR(D2CLIENT, AutomapMode, int, 0xF16B0, 0xF34F8)
 VARPTR(D2CLIENT, Offset, POINT, 0x11C1F8, 0x11CF5C)
-VARPTR(D2CLIENT, xShake, int, 0x11BF00, 0x11CA6C) //ScreenShake	
+VARPTR(D2CLIENT, xShake, int, 0x11BF00, 0x11CA6C) //ScreenShake
 VARPTR(D2CLIENT, yShake, int, 0x10B9DC, 0xFC3DC) //ScreenShake
 VARPTR(D2CLIENT, AutomapLayer, AutomapLayer*, 0x11C1C4, 0x11CF28)
 
@@ -329,7 +329,7 @@ FUNCPTR(D2COMMON, GetObjectText, ObjectTxt * __stdcall, (DWORD objno), -10688, -
 FUNCPTR(D2COMMON, GetItemText, ItemText *__stdcall, (DWORD dwItemNo), -10695, -10994)
 
 FUNCPTR(D2COMMON, GetLayer, AutomapLayer2* __fastcall, (DWORD dwLevelNo), -10749, -10087)
-FUNCPTR(D2COMMON, GetLevel, Level * __fastcall, (ActMisc *pMisc, DWORD dwLevelNo), -10207, -10287)
+FUNCPTR(D2COMMON, GetLevel, Level * __fastcall, (ActMisc *pMisc, DWORD dwLevelNo), -10207, -10283)
 
 FUNCPTR(D2COMMON, GetStatList, StatList* __stdcall, (UnitAny* pUnit, DWORD dwUnk, DWORD dwMaxEntries ), -10930, -10449)
 FUNCPTR(D2COMMON, CopyStatList, DWORD __stdcall, (StatList* pStatList, Stat* pStatArray, DWORD dwMaxEntries), -10658, -10195)
@@ -418,7 +418,7 @@ FUNCPTR(D2GFX, DrawRectangle, void __stdcall, (int X1, int Y1, int X2, int Y2, D
 FUNCPTR(D2GFX, DrawAutomapCell2, void __stdcall, (CellContext* context, DWORD xpos, DWORD ypos, DWORD bright2, DWORD bright, BYTE *coltab), -10041, -10042)
 FUNCPTR(D2GFX, DrawCellContextEx, void __stdcall, (CellContext *context, int Xpos, int Ypos, int dwl, int nTransLvl, BYTE Color), -10019, -10067)
 
-FUNCPTR(D2GFX, GetScreenSize, DWORD __stdcall, (void), -10031, -10012) 
+FUNCPTR(D2GFX, GetScreenSize, DWORD __stdcall, (void), -10031, -10012)
 
 FUNCPTR(D2GFX, GetHwnd, HWND __stdcall, (void), -10048, -10007)
 

--- a/BH/MPQInit.cpp
+++ b/BH/MPQInit.cpp
@@ -1191,199 +1191,202 @@ void InitializeMPQData() {
 			}
 		}
 
-        data = MpqDataMap.find("weapons");
-        if (data != MpqDataMap.end())
+
+
+    }
+
+    data = MpqDataMap.find("weapons");
+    if (data != MpqDataMap.end())
+    {
+        for (auto d = data->second->data.begin(); d < data->second->data.end(); d++)
         {
-            for (auto d = data->second->data.begin(); d < data->second->data.end(); d++)
+            if ((*d)["code"].length() > 0)
             {
-                if ((*d)["code"].length() > 0)
+                std::set<std::string> ancestorTypes;
+                char stackable = ((*d)["stackable"].length() > 0 ? (*d)["stackable"].at(0) - 48 : 0),
+                     useable = ((*d)["useable"].length() > 0 ? (*d)["useable"].at(0) - 48 : 0),
+                     throwable = ((*d)["throwable"].length() > 0 ? (*d)["throwable"].at(0) - 48 : 0);
+                unsigned int flags = ITEM_GROUP_ALLWEAPON, flags2 = 0;
+                FindAncestorTypes((*d)["type"], ancestorTypes, parentMap1, parentMap2);
+
+                if ((*d)["code"].compare((*d)["ultracode"]) == 0)
                 {
-                    std::set<std::string> ancestorTypes;
-                    char stackable = ((*d)["stackable"].length() > 0 ? (*d)["stackable"].at(0) - 48 : 0),
-                         useable = ((*d)["useable"].length() > 0 ? (*d)["useable"].at(0) - 48 : 0),
-                         throwable = ((*d)["throwable"].length() > 0 ? (*d)["throwable"].at(0) - 48 : 0);
-                    unsigned int flags = ITEM_GROUP_ALLWEAPON, flags2 = 0;
-                    FindAncestorTypes((*d)["type"], ancestorTypes, parentMap1, parentMap2);
-
-                    if ((*d)["code"].compare((*d)["ultracode"]) == 0)
-                    {
-                        flags |= ITEM_GROUP_ELITE;
-                    }
-                    else if ((*d)["code"].compare((*d)["ubercode"]) == 0)
-                    {
-                        flags |= ITEM_GROUP_EXCEPTIONAL;
-                    }
-                    else
-                    {
-                        flags |= ITEM_GROUP_NORMAL;
-                    }
-                    if (ancestorTypes.find("club") != ancestorTypes.end() ||
-                        ancestorTypes.find("hamm") != ancestorTypes.end() ||
-                        ancestorTypes.find("mace") != ancestorTypes.end())
-                    {
-                        flags |= ITEM_GROUP_MACE;
-                    }
-                    else if (ancestorTypes.find("wand") != ancestorTypes.end())
-                    {
-                        flags |= ITEM_GROUP_WAND;
-                    }
-                    else if (ancestorTypes.find("staf") != ancestorTypes.end())
-                    {
-                        flags |= ITEM_GROUP_STAFF;
-                    }
-                    else if (ancestorTypes.find("bow") != ancestorTypes.end())
-                    {
-                        flags |= ITEM_GROUP_BOW;
-                    }
-                    else if (ancestorTypes.find("axe") != ancestorTypes.end())
-                    {
-                        flags |= ITEM_GROUP_AXE;
-                    }
-                    else if (ancestorTypes.find("scep") != ancestorTypes.end())
-                    {
-                        flags |= ITEM_GROUP_SCEPTER;
-                    }
-                    else if (ancestorTypes.find("swor") != ancestorTypes.end())
-                    {
-                        flags |= ITEM_GROUP_SWORD;
-                    }
-                    else if (ancestorTypes.find("knif") != ancestorTypes.end())
-                    {
-                        flags |= ITEM_GROUP_DAGGER;
-                    }
-                    else if (ancestorTypes.find("spea") != ancestorTypes.end())
-                    {
-                        flags |= ITEM_GROUP_SPEAR;
-                    }
-                    else if (ancestorTypes.find("pole") != ancestorTypes.end())
-                    {
-                        flags |= ITEM_GROUP_POLEARM;
-                    }
-                    else if (ancestorTypes.find("xbow") != ancestorTypes.end())
-                    {
-                        flags |= ITEM_GROUP_CROSSBOW;
-                    }
-                    else if (ancestorTypes.find("jave") != ancestorTypes.end())
-                    {
-                        flags |= ITEM_GROUP_JAVELIN;
-                    }
-                    if (ancestorTypes.find("thro") != ancestorTypes.end())
-                    {
-                        flags |= ITEM_GROUP_THROWING;
-                    }
-                    flags = AssignClassFlags((*d)["type"], ancestorTypes, flags);
-
-                    ItemAttributes *attrs = new ItemAttributes();
-                    attrs->name = (*d)["name"];
-                    attrs->code[0] = (*d)["code"].c_str()[0];
-                    attrs->code[1] = (*d)["code"].c_str()[1];
-                    attrs->code[2] = (*d)["code"].c_str()[2];
-                    attrs->code[3] = 0;
-                    attrs->category = (*d)["type"];
-                    attrs->width = (*d)["invwidth"].at(0) - '0';
-                    attrs->height = (*d)["invheight"].at(0) - '0';
-                    attrs->stackable = stackable;
-                    attrs->useable = useable;
-                    attrs->throwable = throwable;
-                    attrs->itemLevel = 0;
-                    attrs->unusedFlags = 0;
-                    attrs->flags = flags;
-                    attrs->flags2 = flags2;
-                    attrs->qualityLevel = stoi((*d)["level"], nullptr, 10);
-                    attrs->magicLevel = atoi((*d)["magic lvl"].c_str());
-                    ItemAttributeMap[(*d)["code"]] = attrs;
+                    flags |= ITEM_GROUP_ELITE;
                 }
+                else if ((*d)["code"].compare((*d)["ubercode"]) == 0)
+                {
+                    flags |= ITEM_GROUP_EXCEPTIONAL;
+                }
+                else
+                {
+                    flags |= ITEM_GROUP_NORMAL;
+                }
+                if (ancestorTypes.find("club") != ancestorTypes.end() ||
+                    ancestorTypes.find("hamm") != ancestorTypes.end() ||
+                    ancestorTypes.find("mace") != ancestorTypes.end())
+                {
+                    flags |= ITEM_GROUP_MACE;
+                }
+                else if (ancestorTypes.find("wand") != ancestorTypes.end())
+                {
+                    flags |= ITEM_GROUP_WAND;
+                }
+                else if (ancestorTypes.find("staf") != ancestorTypes.end())
+                {
+                    flags |= ITEM_GROUP_STAFF;
+                }
+                else if (ancestorTypes.find("bow") != ancestorTypes.end())
+                {
+                    flags |= ITEM_GROUP_BOW;
+                }
+                else if (ancestorTypes.find("axe") != ancestorTypes.end())
+                {
+                    flags |= ITEM_GROUP_AXE;
+                }
+                else if (ancestorTypes.find("scep") != ancestorTypes.end())
+                {
+                    flags |= ITEM_GROUP_SCEPTER;
+                }
+                else if (ancestorTypes.find("swor") != ancestorTypes.end())
+                {
+                    flags |= ITEM_GROUP_SWORD;
+                }
+                else if (ancestorTypes.find("knif") != ancestorTypes.end())
+                {
+                    flags |= ITEM_GROUP_DAGGER;
+                }
+                else if (ancestorTypes.find("spea") != ancestorTypes.end())
+                {
+                    flags |= ITEM_GROUP_SPEAR;
+                }
+                else if (ancestorTypes.find("pole") != ancestorTypes.end())
+                {
+                    flags |= ITEM_GROUP_POLEARM;
+                }
+                else if (ancestorTypes.find("xbow") != ancestorTypes.end())
+                {
+                    flags |= ITEM_GROUP_CROSSBOW;
+                }
+                else if (ancestorTypes.find("jave") != ancestorTypes.end())
+                {
+                    flags |= ITEM_GROUP_JAVELIN;
+                }
+                if (ancestorTypes.find("thro") != ancestorTypes.end())
+                {
+                    flags |= ITEM_GROUP_THROWING;
+                }
+                flags = AssignClassFlags((*d)["type"], ancestorTypes, flags);
+
+                ItemAttributes *attrs = new ItemAttributes();
+                attrs->name = (*d)["name"];
+                attrs->code[0] = (*d)["code"].c_str()[0];
+                attrs->code[1] = (*d)["code"].c_str()[1];
+                attrs->code[2] = (*d)["code"].c_str()[2];
+                attrs->code[3] = 0;
+                attrs->category = (*d)["type"];
+                attrs->width = (*d)["invwidth"].at(0) - '0';
+                attrs->height = (*d)["invheight"].at(0) - '0';
+                attrs->stackable = stackable;
+                attrs->useable = useable;
+                attrs->throwable = throwable;
+                attrs->itemLevel = 0;
+                attrs->unusedFlags = 0;
+                attrs->flags = flags;
+                attrs->flags2 = flags2;
+                attrs->qualityLevel = stoi((*d)["level"], nullptr, 10);
+                attrs->magicLevel = atoi((*d)["magic lvl"].c_str());
+                ItemAttributeMap[(*d)["code"]] = attrs;
             }
         }
+    }
 
-        data = MpqDataMap.find("misc");
-        if (data != MpqDataMap.end())
+    data = MpqDataMap.find("misc");
+    if (data != MpqDataMap.end())
+    {
+        for (auto d = data->second->data.begin(); d < data->second->data.end(); d++)
         {
-            for (auto d = data->second->data.begin(); d < data->second->data.end(); d++)
+            if ((*d)["code"].length() > 0)
             {
-                if ((*d)["code"].length() > 0)
+                std::set<std::string> ancestorTypes;
+                char stackable = ((*d)["stackable"].length() > 0 ? (*d)["stackable"].at(0) - 48 : 0),
+                     useable = ((*d)["useable"].length() > 0 ? (*d)["useable"].at(0) - 48 : 0),
+                     throwable = ((*d)["throwable"].length() > 0 ? (*d)["throwable"].at(0) - 48 : 0);
+                unsigned int flags = 0, flags2 = 0;
+                FindAncestorTypes((*d)["type"], ancestorTypes, parentMap1, parentMap2);
+                FindAncestorTypes((*d)["type2"], ancestorTypes, parentMap1, parentMap2);
+
+                if (ancestorTypes.find("rune") != ancestorTypes.end())
                 {
-                    std::set<std::string> ancestorTypes;
-                    char stackable = ((*d)["stackable"].length() > 0 ? (*d)["stackable"].at(0) - 48 : 0),
-                         useable = ((*d)["useable"].length() > 0 ? (*d)["useable"].at(0) - 48 : 0),
-                         throwable = ((*d)["throwable"].length() > 0 ? (*d)["throwable"].at(0) - 48 : 0);
-                    unsigned int flags = 0, flags2 = 0;
-                    FindAncestorTypes((*d)["type"], ancestorTypes, parentMap1, parentMap2);
-                    FindAncestorTypes((*d)["type2"], ancestorTypes, parentMap1, parentMap2);
-
-                    if (ancestorTypes.find("rune") != ancestorTypes.end())
-                    {
-                        flags2 |= ITEM_GROUP_RUNE;
-                    }
-                    if (ancestorTypes.find("gem0") != ancestorTypes.end())
-                    {
-                        flags2 |= ITEM_GROUP_CHIPPED;
-                    }
-                    else if (ancestorTypes.find("gem1") != ancestorTypes.end())
-                    {
-                        flags2 |= ITEM_GROUP_FLAWED;
-                    }
-                    else if (ancestorTypes.find("gem2") != ancestorTypes.end())
-                    {
-                        flags2 |= ITEM_GROUP_REGULAR;
-                    }
-                    else if (ancestorTypes.find("gem3") != ancestorTypes.end())
-                    {
-                        flags2 |= ITEM_GROUP_FLAWLESS;
-                    }
-                    else if (ancestorTypes.find("gem4") != ancestorTypes.end())
-                    {
-                        flags2 |= ITEM_GROUP_PERFECT;
-                    }
-                    if (ancestorTypes.find("gema") != ancestorTypes.end())
-                    {
-                        flags2 |= ITEM_GROUP_AMETHYST;
-                    }
-                    else if (ancestorTypes.find("gemd") != ancestorTypes.end())
-                    {
-                        flags2 |= ITEM_GROUP_DIAMOND;
-                    }
-                    else if (ancestorTypes.find("geme") != ancestorTypes.end())
-                    {
-                        flags2 |= ITEM_GROUP_EMERALD;
-                    }
-                    else if (ancestorTypes.find("gemr") != ancestorTypes.end())
-                    {
-                        flags2 |= ITEM_GROUP_RUBY;
-                    }
-                    else if (ancestorTypes.find("gems") != ancestorTypes.end())
-                    {
-                        flags2 |= ITEM_GROUP_SAPPHIRE;
-                    }
-                    else if (ancestorTypes.find("gemt") != ancestorTypes.end())
-                    {
-                        flags2 |= ITEM_GROUP_TOPAZ;
-                    }
-                    else if (ancestorTypes.find("gemz") != ancestorTypes.end())
-                    {
-                        flags2 |= ITEM_GROUP_SKULL;
-                    }
-
-                    ItemAttributes *attrs = new ItemAttributes();
-                    attrs->name = (*d)["name"];
-                    attrs->code[0] = (*d)["code"].c_str()[0];
-                    attrs->code[1] = (*d)["code"].c_str()[1];
-                    attrs->code[2] = (*d)["code"].c_str()[2];
-                    attrs->code[3] = 0;
-                    attrs->category = (*d)["type"];
-                    attrs->width = (*d)["invwidth"].at(0) - '0';
-                    attrs->height = (*d)["invheight"].at(0) - '0';
-                    attrs->stackable = stackable;
-                    attrs->useable = useable;
-                    attrs->throwable = throwable;
-                    attrs->itemLevel = 0;
-                    attrs->unusedFlags = 0;
-                    attrs->flags = flags;
-                    attrs->flags2 = flags2;
-                    attrs->qualityLevel = stoi((*d)["level"], nullptr, 10);
-                    attrs->magicLevel = 0;
-                    ItemAttributeMap[(*d)["code"]] = attrs;
+                    flags2 |= ITEM_GROUP_RUNE;
                 }
+                if (ancestorTypes.find("gem0") != ancestorTypes.end())
+                {
+                    flags2 |= ITEM_GROUP_CHIPPED;
+                }
+                else if (ancestorTypes.find("gem1") != ancestorTypes.end())
+                {
+                    flags2 |= ITEM_GROUP_FLAWED;
+                }
+                else if (ancestorTypes.find("gem2") != ancestorTypes.end())
+                {
+                    flags2 |= ITEM_GROUP_REGULAR;
+                }
+                else if (ancestorTypes.find("gem3") != ancestorTypes.end())
+                {
+                    flags2 |= ITEM_GROUP_FLAWLESS;
+                }
+                else if (ancestorTypes.find("gem4") != ancestorTypes.end())
+                {
+                    flags2 |= ITEM_GROUP_PERFECT;
+                }
+                if (ancestorTypes.find("gema") != ancestorTypes.end())
+                {
+                    flags2 |= ITEM_GROUP_AMETHYST;
+                }
+                else if (ancestorTypes.find("gemd") != ancestorTypes.end())
+                {
+                    flags2 |= ITEM_GROUP_DIAMOND;
+                }
+                else if (ancestorTypes.find("geme") != ancestorTypes.end())
+                {
+                    flags2 |= ITEM_GROUP_EMERALD;
+                }
+                else if (ancestorTypes.find("gemr") != ancestorTypes.end())
+                {
+                    flags2 |= ITEM_GROUP_RUBY;
+                }
+                else if (ancestorTypes.find("gems") != ancestorTypes.end())
+                {
+                    flags2 |= ITEM_GROUP_SAPPHIRE;
+                }
+                else if (ancestorTypes.find("gemt") != ancestorTypes.end())
+                {
+                    flags2 |= ITEM_GROUP_TOPAZ;
+                }
+                else if (ancestorTypes.find("gemz") != ancestorTypes.end())
+                {
+                    flags2 |= ITEM_GROUP_SKULL;
+                }
+
+                ItemAttributes *attrs = new ItemAttributes();
+                attrs->name = (*d)["name"];
+                attrs->code[0] = (*d)["code"].c_str()[0];
+                attrs->code[1] = (*d)["code"].c_str()[1];
+                attrs->code[2] = (*d)["code"].c_str()[2];
+                attrs->code[3] = 0;
+                attrs->category = (*d)["type"];
+                attrs->width = (*d)["invwidth"].at(0) - '0';
+                attrs->height = (*d)["invheight"].at(0) - '0';
+                attrs->stackable = stackable;
+                attrs->useable = useable;
+                attrs->throwable = throwable;
+                attrs->itemLevel = 0;
+                attrs->unusedFlags = 0;
+                attrs->flags = flags;
+                attrs->flags2 = flags2;
+                attrs->qualityLevel = stoi((*d)["level"], nullptr, 10);
+                attrs->magicLevel = 0;
+                ItemAttributeMap[(*d)["code"]] = attrs;
             }
         }
     }

--- a/BH/MPQInit.cpp
+++ b/BH/MPQInit.cpp
@@ -1044,55 +1044,64 @@ bool IsInitialized() {
 // If we find the temp file with MPQ info, use it; otherwise, fall back on the hardcoded lists.
 void InitializeMPQData() {
 	if (initialized) return;
-	
+
 	char* end;
 	short lastID = -1;
 
-	for (auto d = MpqDataMap["skills"]->data.begin(); d < MpqDataMap["skills"]->data.end(); d++) {
-		if ((*d)["Id"].length() > 0) {
-			unsigned short id = (unsigned short)std::strtoul((*d)["Id"].c_str(), &end, 10);
-			if (id > SKILL_MAX) {
-				SKILL_MAX = id;
+	auto data = MpqDataMap.find("skills");
+	if (data != MpqDataMap.end()) {
+		for (auto d = data->second->data.begin(); d < data->second->data.end(); d++) {
+			if ((*d)["Id"].length() > 0) {
+				unsigned short id = (unsigned short)std::strtoul((*d)["Id"].c_str(), &end, 10);
+				if (id > SKILL_MAX) {
+					SKILL_MAX = id;
+				}
 			}
-    }
-  }
-
-	for (auto d = MpqDataMap["charstats"]->data.begin(); d < MpqDataMap["charstats"]->data.end(); d++) {
-		if ((*d)["ToHitFactor"].length() > 0) {
-			CharStats *bits = new CharStats();
-			bits->toHitFactor = std::stoi((*d)["ToHitFactor"].c_str(), nullptr, 10);
-			CharList.push_back(bits);
 		}
 	}
 
-	for (auto d = MpqDataMap["itemstatcost"]->data.begin(); d < MpqDataMap["itemstatcost"]->data.end(); d++) {
-		if ((*d)["ID"].length() > 0) {
-			unsigned short id = (unsigned short)std::strtoul((*d)["ID"].c_str(), &end, 10);
-			if (id > STAT_MAX) {
-				STAT_MAX = id;
+	data = MpqDataMap.find("charstats");
+	if (data != MpqDataMap.end()) {
+		for (auto d = data->second->data.begin(); d < data->second->data.end(); d++) {
+			if ((*d)["ToHitFactor"].length() > 0) {
+				CharStats* bits = new CharStats();
+				bits->toHitFactor = std::stoi((*d)["ToHitFactor"].c_str(), nullptr, 10);
+				CharList.push_back(bits);
 			}
+		}
+	}
 
-			for (int missing = lastID + 1; missing < id; missing++) {
-				StatProperties *mbits = new StatProperties();
-				mbits->name.assign("missing_id");
-				mbits->ID = missing;
-				mbits->sendParamBits = mbits->saveBits = mbits->saveAdd = mbits->saveParamBits = mbits->op = 0;
-				AllStatList.push_back(mbits);
-				StatMap[mbits->name] = mbits;
+	data = MpqDataMap.find("itemstatcost");
+	if (data != MpqDataMap.end()) {
+		for (auto d = data->second->data.begin(); d < data->second->data.end(); d++) {
+			if ((*d)["ID"].length() > 0) {
+				unsigned short id = (unsigned short)std::strtoul((*d)["ID"].c_str(), &end, 10);
+				if (id > STAT_MAX) {
+					STAT_MAX = id;
+				}
+
+				for (int missing = lastID + 1; missing < id; missing++) {
+					StatProperties* mbits = new StatProperties();
+					mbits->name.assign("missing_id");
+					mbits->ID = missing;
+					mbits->sendParamBits = mbits->saveBits = mbits->saveAdd = mbits->saveParamBits = mbits->op = 0;
+					AllStatList.push_back(mbits);
+					StatMap[mbits->name] = mbits;
+				}
+
+				StatProperties* bits = new StatProperties();
+				bits->name = (*d)["Stat"];
+				std::transform(bits->name.begin(), bits->name.end(), bits->name.begin(), tolower);
+				bits->ID = id;
+				bits->sendParamBits = (BYTE)std::strtoul((*d)["Send Param Bits"].c_str(), &end, 10);
+				bits->saveBits = (BYTE)std::strtoul((*d)["Save Bits"].c_str(), &end, 10);
+				bits->saveAdd = (BYTE)std::strtoul((*d)["Save Add"].c_str(), &end, 10);
+				bits->saveParamBits = (BYTE)std::strtoul((*d)["Save Param Bits"].c_str(), &end, 10);
+				bits->op = (BYTE)std::strtoul((*d)["op"].c_str(), &end, 10);
+				AllStatList.push_back(bits);
+				StatMap[bits->name] = bits;
+				lastID = (short)id;
 			}
-
-			StatProperties *bits = new StatProperties();
-			bits->name = (*d)["Stat"];
-			std::transform(bits->name.begin(), bits->name.end(), bits->name.begin(), tolower);
-			bits->ID = id;
-			bits->sendParamBits = (BYTE)std::strtoul((*d)["Send Param Bits"].c_str(), &end, 10);
-			bits->saveBits = (BYTE)std::strtoul((*d)["Save Bits"].c_str(), &end, 10);
-			bits->saveAdd = (BYTE)std::strtoul((*d)["Save Add"].c_str(), &end, 10);
-			bits->saveParamBits = (BYTE)std::strtoul((*d)["Save Param Bits"].c_str(), &end, 10);
-			bits->op = (BYTE)std::strtoul((*d)["op"].c_str(), &end, 10);
-			AllStatList.push_back(bits);
-			StatMap[bits->name] = bits;
-			lastID = (short)id;
 		}
 	}
 
@@ -1100,89 +1109,32 @@ void InitializeMPQData() {
 	std::map<std::string, std::string> bodyLocMap;
 	std::map<std::string, std::string> parentMap1;
 	std::map<std::string, std::string> parentMap2;
-	for (auto d = MpqDataMap["itemtypes"]->data.begin(); d < MpqDataMap["itemtypes"]->data.end(); d++) {
-		if ((*d)["Code"].length() > 0) {
-			throwableMap[(*d)["Code"]] = (*d)["Throwable"];
-			bodyLocMap[(*d)["Code"]] = (*d)["BodyLoc1"];
-			if ((*d)["Equiv1"].length() > 0) {
-				parentMap1[(*d)["Code"]] = (*d)["Equiv1"];
-			}
-			if ((*d)["Equiv2"].length() > 0) {
-				parentMap2[(*d)["Code"]] = (*d)["Equiv2"];
+	data = MpqDataMap.find("itemtypes");
+	if (data != MpqDataMap.end()) {
+		for (auto d = data->second->data.begin(); d < data->second->data.end(); d++) {
+			if ((*d)["Code"].length() > 0) {
+				throwableMap[(*d)["Code"]] = (*d)["Throwable"];
+				bodyLocMap[(*d)["Code"]] = (*d)["BodyLoc1"];
+				if ((*d)["Equiv1"].length() > 0) {
+					parentMap1[(*d)["Code"]] = (*d)["Equiv1"];
+				}
+				if ((*d)["Equiv2"].length() > 0) {
+					parentMap2[(*d)["Code"]] = (*d)["Equiv2"];
+				}
 			}
 		}
 	}
 
-	for (auto d = MpqDataMap["armor"]->data.begin(); d < MpqDataMap["armor"]->data.end(); d++) {
-		if ((*d)["code"].length() > 0) {
-			std::set<std::string> ancestorTypes;
-			char stackable = ((*d)["stackable"].length() > 0 ? (*d)["stackable"].at(0) - 48 : 0),
-				useable = ((*d)["useable"].length() > 0 ? (*d)["useable"].at(0) - 48 : 0),
-				throwable = ((*d)["throwable"].length() > 0 ? (*d)["throwable"].at(0) - 48 : 0);
-
-			unsigned int flags = ITEM_GROUP_ALLARMOR, flags2 = 0;
-			FindAncestorTypes((*d)["type"], ancestorTypes, parentMap1, parentMap2);
-
-			if ((*d)["code"].compare((*d)["ultracode"]) == 0) {
-				flags |= ITEM_GROUP_ELITE;
-			}
-			else if ((*d)["code"].compare((*d)["ubercode"]) == 0) {
-				flags |= ITEM_GROUP_EXCEPTIONAL;
-			}
-			else {
-				flags |= ITEM_GROUP_NORMAL;
-			}
-			if (ancestorTypes.find("circ") != ancestorTypes.end()) {
-				flags |= ITEM_GROUP_CIRCLET;
-			}
-			else if (bodyLocMap[(*d)["type"]].compare("head") == 0) {
-				flags |= ITEM_GROUP_HELM;
-			}
-			else if (bodyLocMap[(*d)["type"]].compare("tors") == 0) {
-				flags |= ITEM_GROUP_ARMOR;
-			}
-			else if (bodyLocMap[(*d)["type"]].compare("glov") == 0) {
-				flags |= ITEM_GROUP_GLOVES;
-			}
-			else if (bodyLocMap[(*d)["type"]].compare("feet") == 0) {
-				flags |= ITEM_GROUP_BOOTS;
-			}
-			else if (bodyLocMap[(*d)["type"]].compare("belt") == 0) {
-				flags |= ITEM_GROUP_BELT;
-			}
-			else if (bodyLocMap[(*d)["type"]].compare(1, 3, "arm") == 0 && ancestorTypes.find("shld") != ancestorTypes.end()) {
-				flags |= ITEM_GROUP_SHIELD;
-			}
-			flags = AssignClassFlags((*d)["type"], ancestorTypes, flags);
-
-			ItemAttributes *attrs = new ItemAttributes();
-			attrs->name = (*d)["name"];
-			attrs->code[0] = (*d)["code"].c_str()[0];
-			attrs->code[1] = (*d)["code"].c_str()[1];
-			attrs->code[2] = (*d)["code"].c_str()[2];
-			attrs->code[3] = 0;
-			attrs->category = (*d)["type"];
-			attrs->width = (*d)["invwidth"].at(0) - '0';
-			attrs->height = (*d)["invheight"].at(0) - '0';
-			attrs->stackable = stackable;
-			attrs->useable = useable;
-			attrs->throwable = throwable;
-			attrs->itemLevel = 0;
-			attrs->unusedFlags = 0;
-			attrs->flags = flags;
-			attrs->flags2 = flags2;
-			attrs->qualityLevel = stoi((*d)["level"], nullptr, 10);
-			attrs->magicLevel = atoi((*d)["magic lvl"].c_str());
-			ItemAttributeMap[(*d)["code"]] = attrs;
-		}
-
-		for (auto d = MpqDataMap["weapons"]->data.begin(); d < MpqDataMap["weapons"]->data.end(); d++) {
+	data = MpqDataMap.find("armor");
+	if (data != MpqDataMap.end()) {
+		for (auto d = data->second->data.begin(); d < data->second->data.end(); d++) {
 			if ((*d)["code"].length() > 0) {
 				std::set<std::string> ancestorTypes;
 				char stackable = ((*d)["stackable"].length() > 0 ? (*d)["stackable"].at(0) - 48 : 0),
 					useable = ((*d)["useable"].length() > 0 ? (*d)["useable"].at(0) - 48 : 0),
 					throwable = ((*d)["throwable"].length() > 0 ? (*d)["throwable"].at(0) - 48 : 0);
-				unsigned int flags = ITEM_GROUP_ALLWEAPON, flags2 = 0;
+
+				unsigned int flags = ITEM_GROUP_ALLARMOR, flags2 = 0;
 				FindAncestorTypes((*d)["type"], ancestorTypes, parentMap1, parentMap2);
 
 				if ((*d)["code"].compare((*d)["ultracode"]) == 0) {
@@ -1194,50 +1146,30 @@ void InitializeMPQData() {
 				else {
 					flags |= ITEM_GROUP_NORMAL;
 				}
-				if (ancestorTypes.find("club") != ancestorTypes.end() ||
-					ancestorTypes.find("hamm") != ancestorTypes.end() ||
-					ancestorTypes.find("mace") != ancestorTypes.end()) {
-					flags |= ITEM_GROUP_MACE;
+				if (ancestorTypes.find("circ") != ancestorTypes.end()) {
+					flags |= ITEM_GROUP_CIRCLET;
 				}
-				else if (ancestorTypes.find("wand") != ancestorTypes.end()) {
-					flags |= ITEM_GROUP_WAND;
+				else if (bodyLocMap[(*d)["type"]].compare("head") == 0) {
+					flags |= ITEM_GROUP_HELM;
 				}
-				else if (ancestorTypes.find("staf") != ancestorTypes.end()) {
-					flags |= ITEM_GROUP_STAFF;
+				else if (bodyLocMap[(*d)["type"]].compare("tors") == 0) {
+					flags |= ITEM_GROUP_ARMOR;
 				}
-				else if (ancestorTypes.find("bow") != ancestorTypes.end()) {
-					flags |= ITEM_GROUP_BOW;
+				else if (bodyLocMap[(*d)["type"]].compare("glov") == 0) {
+					flags |= ITEM_GROUP_GLOVES;
 				}
-				else if (ancestorTypes.find("axe") != ancestorTypes.end()) {
-					flags |= ITEM_GROUP_AXE;
+				else if (bodyLocMap[(*d)["type"]].compare("feet") == 0) {
+					flags |= ITEM_GROUP_BOOTS;
 				}
-				else if (ancestorTypes.find("scep") != ancestorTypes.end()) {
-					flags |= ITEM_GROUP_SCEPTER;
+				else if (bodyLocMap[(*d)["type"]].compare("belt") == 0) {
+					flags |= ITEM_GROUP_BELT;
 				}
-				else if (ancestorTypes.find("swor") != ancestorTypes.end()) {
-					flags |= ITEM_GROUP_SWORD;
-				}
-				else if (ancestorTypes.find("knif") != ancestorTypes.end()) {
-					flags |= ITEM_GROUP_DAGGER;
-				}
-				else if (ancestorTypes.find("spea") != ancestorTypes.end()) {
-					flags |= ITEM_GROUP_SPEAR;
-				}
-				else if (ancestorTypes.find("pole") != ancestorTypes.end()) {
-					flags |= ITEM_GROUP_POLEARM;
-				}
-				else if (ancestorTypes.find("xbow") != ancestorTypes.end()) {
-					flags |= ITEM_GROUP_CROSSBOW;
-				}
-				else if (ancestorTypes.find("jave") != ancestorTypes.end()) {
-					flags |= ITEM_GROUP_JAVELIN;
-				}
-				if (ancestorTypes.find("thro") != ancestorTypes.end()) {
-					flags |= ITEM_GROUP_THROWING;
+				else if (bodyLocMap[(*d)["type"]].compare(1, 3, "arm") == 0 && ancestorTypes.find("shld") != ancestorTypes.end()) {
+					flags |= ITEM_GROUP_SHIELD;
 				}
 				flags = AssignClassFlags((*d)["type"], ancestorTypes, flags);
 
-				ItemAttributes *attrs = new ItemAttributes();
+				ItemAttributes* attrs = new ItemAttributes();
 				attrs->name = (*d)["name"];
 				attrs->code[0] = (*d)["code"].c_str()[0];
 				attrs->code[1] = (*d)["code"].c_str()[1];
@@ -1259,78 +1191,202 @@ void InitializeMPQData() {
 			}
 		}
 
-		for (auto d = MpqDataMap["misc"]->data.begin(); d < MpqDataMap["misc"]->data.end(); d++) {
-			if ((*d)["code"].length() > 0) {
-				std::set<std::string> ancestorTypes;
-				char stackable = ((*d)["stackable"].length() > 0 ? (*d)["stackable"].at(0) - 48 : 0),
-					useable = ((*d)["useable"].length() > 0 ? (*d)["useable"].at(0) - 48 : 0),
-					throwable = ((*d)["throwable"].length() > 0 ? (*d)["throwable"].at(0) - 48 : 0);
-				unsigned int flags = 0, flags2 = 0;
-				FindAncestorTypes((*d)["type"], ancestorTypes, parentMap1, parentMap2);
-				FindAncestorTypes((*d)["type2"], ancestorTypes, parentMap1, parentMap2);
+        data = MpqDataMap.find("weapons");
+        if (data != MpqDataMap.end())
+        {
+            for (auto d = data->second->data.begin(); d < data->second->data.end(); d++)
+            {
+                if ((*d)["code"].length() > 0)
+                {
+                    std::set<std::string> ancestorTypes;
+                    char stackable = ((*d)["stackable"].length() > 0 ? (*d)["stackable"].at(0) - 48 : 0),
+                         useable = ((*d)["useable"].length() > 0 ? (*d)["useable"].at(0) - 48 : 0),
+                         throwable = ((*d)["throwable"].length() > 0 ? (*d)["throwable"].at(0) - 48 : 0);
+                    unsigned int flags = ITEM_GROUP_ALLWEAPON, flags2 = 0;
+                    FindAncestorTypes((*d)["type"], ancestorTypes, parentMap1, parentMap2);
 
-				if (ancestorTypes.find("rune") != ancestorTypes.end()) {
-					flags2 |= ITEM_GROUP_RUNE;
-				}
-				if (ancestorTypes.find("gem0") != ancestorTypes.end()) {
-					flags2 |= ITEM_GROUP_CHIPPED;
-				}
-				else if (ancestorTypes.find("gem1") != ancestorTypes.end()) {
-					flags2 |= ITEM_GROUP_FLAWED;
-				}
-				else if (ancestorTypes.find("gem2") != ancestorTypes.end()) {
-					flags2 |= ITEM_GROUP_REGULAR;
-				}
-				else if (ancestorTypes.find("gem3") != ancestorTypes.end()) {
-					flags2 |= ITEM_GROUP_FLAWLESS;
-				}
-				else if (ancestorTypes.find("gem4") != ancestorTypes.end()) {
-					flags2 |= ITEM_GROUP_PERFECT;
-				}
-				if (ancestorTypes.find("gema") != ancestorTypes.end()) {
-					flags2 |= ITEM_GROUP_AMETHYST;
-				}
-				else if (ancestorTypes.find("gemd") != ancestorTypes.end()) {
-					flags2 |= ITEM_GROUP_DIAMOND;
-				}
-				else if (ancestorTypes.find("geme") != ancestorTypes.end()) {
-					flags2 |= ITEM_GROUP_EMERALD;
-				}
-				else if (ancestorTypes.find("gemr") != ancestorTypes.end()) {
-					flags2 |= ITEM_GROUP_RUBY;
-				}
-				else if (ancestorTypes.find("gems") != ancestorTypes.end()) {
-					flags2 |= ITEM_GROUP_SAPPHIRE;
-				}
-				else if (ancestorTypes.find("gemt") != ancestorTypes.end()) {
-					flags2 |= ITEM_GROUP_TOPAZ;
-				}
-				else if (ancestorTypes.find("gemz") != ancestorTypes.end()) {
-					flags2 |= ITEM_GROUP_SKULL;
-				}
+                    if ((*d)["code"].compare((*d)["ultracode"]) == 0)
+                    {
+                        flags |= ITEM_GROUP_ELITE;
+                    }
+                    else if ((*d)["code"].compare((*d)["ubercode"]) == 0)
+                    {
+                        flags |= ITEM_GROUP_EXCEPTIONAL;
+                    }
+                    else
+                    {
+                        flags |= ITEM_GROUP_NORMAL;
+                    }
+                    if (ancestorTypes.find("club") != ancestorTypes.end() ||
+                        ancestorTypes.find("hamm") != ancestorTypes.end() ||
+                        ancestorTypes.find("mace") != ancestorTypes.end())
+                    {
+                        flags |= ITEM_GROUP_MACE;
+                    }
+                    else if (ancestorTypes.find("wand") != ancestorTypes.end())
+                    {
+                        flags |= ITEM_GROUP_WAND;
+                    }
+                    else if (ancestorTypes.find("staf") != ancestorTypes.end())
+                    {
+                        flags |= ITEM_GROUP_STAFF;
+                    }
+                    else if (ancestorTypes.find("bow") != ancestorTypes.end())
+                    {
+                        flags |= ITEM_GROUP_BOW;
+                    }
+                    else if (ancestorTypes.find("axe") != ancestorTypes.end())
+                    {
+                        flags |= ITEM_GROUP_AXE;
+                    }
+                    else if (ancestorTypes.find("scep") != ancestorTypes.end())
+                    {
+                        flags |= ITEM_GROUP_SCEPTER;
+                    }
+                    else if (ancestorTypes.find("swor") != ancestorTypes.end())
+                    {
+                        flags |= ITEM_GROUP_SWORD;
+                    }
+                    else if (ancestorTypes.find("knif") != ancestorTypes.end())
+                    {
+                        flags |= ITEM_GROUP_DAGGER;
+                    }
+                    else if (ancestorTypes.find("spea") != ancestorTypes.end())
+                    {
+                        flags |= ITEM_GROUP_SPEAR;
+                    }
+                    else if (ancestorTypes.find("pole") != ancestorTypes.end())
+                    {
+                        flags |= ITEM_GROUP_POLEARM;
+                    }
+                    else if (ancestorTypes.find("xbow") != ancestorTypes.end())
+                    {
+                        flags |= ITEM_GROUP_CROSSBOW;
+                    }
+                    else if (ancestorTypes.find("jave") != ancestorTypes.end())
+                    {
+                        flags |= ITEM_GROUP_JAVELIN;
+                    }
+                    if (ancestorTypes.find("thro") != ancestorTypes.end())
+                    {
+                        flags |= ITEM_GROUP_THROWING;
+                    }
+                    flags = AssignClassFlags((*d)["type"], ancestorTypes, flags);
 
-				ItemAttributes *attrs = new ItemAttributes();
-				attrs->name = (*d)["name"];
-				attrs->code[0] = (*d)["code"].c_str()[0];
-				attrs->code[1] = (*d)["code"].c_str()[1];
-				attrs->code[2] = (*d)["code"].c_str()[2];
-				attrs->code[3] = 0;
-				attrs->category = (*d)["type"];
-				attrs->width = (*d)["invwidth"].at(0) - '0';
-				attrs->height = (*d)["invheight"].at(0) - '0';
-				attrs->stackable = stackable;
-				attrs->useable = useable;
-				attrs->throwable = throwable;
-				attrs->itemLevel = 0;
-				attrs->unusedFlags = 0;
-				attrs->flags = flags;
-				attrs->flags2 = flags2;
-				attrs->qualityLevel = stoi((*d)["level"], nullptr, 10);
-				attrs->magicLevel = 0;
-				ItemAttributeMap[(*d)["code"]] = attrs;
-			}
-		}
-	}
+                    ItemAttributes *attrs = new ItemAttributes();
+                    attrs->name = (*d)["name"];
+                    attrs->code[0] = (*d)["code"].c_str()[0];
+                    attrs->code[1] = (*d)["code"].c_str()[1];
+                    attrs->code[2] = (*d)["code"].c_str()[2];
+                    attrs->code[3] = 0;
+                    attrs->category = (*d)["type"];
+                    attrs->width = (*d)["invwidth"].at(0) - '0';
+                    attrs->height = (*d)["invheight"].at(0) - '0';
+                    attrs->stackable = stackable;
+                    attrs->useable = useable;
+                    attrs->throwable = throwable;
+                    attrs->itemLevel = 0;
+                    attrs->unusedFlags = 0;
+                    attrs->flags = flags;
+                    attrs->flags2 = flags2;
+                    attrs->qualityLevel = stoi((*d)["level"], nullptr, 10);
+                    attrs->magicLevel = atoi((*d)["magic lvl"].c_str());
+                    ItemAttributeMap[(*d)["code"]] = attrs;
+                }
+            }
+        }
+
+        data = MpqDataMap.find("misc");
+        if (data != MpqDataMap.end())
+        {
+            for (auto d = data->second->data.begin(); d < data->second->data.end(); d++)
+            {
+                if ((*d)["code"].length() > 0)
+                {
+                    std::set<std::string> ancestorTypes;
+                    char stackable = ((*d)["stackable"].length() > 0 ? (*d)["stackable"].at(0) - 48 : 0),
+                         useable = ((*d)["useable"].length() > 0 ? (*d)["useable"].at(0) - 48 : 0),
+                         throwable = ((*d)["throwable"].length() > 0 ? (*d)["throwable"].at(0) - 48 : 0);
+                    unsigned int flags = 0, flags2 = 0;
+                    FindAncestorTypes((*d)["type"], ancestorTypes, parentMap1, parentMap2);
+                    FindAncestorTypes((*d)["type2"], ancestorTypes, parentMap1, parentMap2);
+
+                    if (ancestorTypes.find("rune") != ancestorTypes.end())
+                    {
+                        flags2 |= ITEM_GROUP_RUNE;
+                    }
+                    if (ancestorTypes.find("gem0") != ancestorTypes.end())
+                    {
+                        flags2 |= ITEM_GROUP_CHIPPED;
+                    }
+                    else if (ancestorTypes.find("gem1") != ancestorTypes.end())
+                    {
+                        flags2 |= ITEM_GROUP_FLAWED;
+                    }
+                    else if (ancestorTypes.find("gem2") != ancestorTypes.end())
+                    {
+                        flags2 |= ITEM_GROUP_REGULAR;
+                    }
+                    else if (ancestorTypes.find("gem3") != ancestorTypes.end())
+                    {
+                        flags2 |= ITEM_GROUP_FLAWLESS;
+                    }
+                    else if (ancestorTypes.find("gem4") != ancestorTypes.end())
+                    {
+                        flags2 |= ITEM_GROUP_PERFECT;
+                    }
+                    if (ancestorTypes.find("gema") != ancestorTypes.end())
+                    {
+                        flags2 |= ITEM_GROUP_AMETHYST;
+                    }
+                    else if (ancestorTypes.find("gemd") != ancestorTypes.end())
+                    {
+                        flags2 |= ITEM_GROUP_DIAMOND;
+                    }
+                    else if (ancestorTypes.find("geme") != ancestorTypes.end())
+                    {
+                        flags2 |= ITEM_GROUP_EMERALD;
+                    }
+                    else if (ancestorTypes.find("gemr") != ancestorTypes.end())
+                    {
+                        flags2 |= ITEM_GROUP_RUBY;
+                    }
+                    else if (ancestorTypes.find("gems") != ancestorTypes.end())
+                    {
+                        flags2 |= ITEM_GROUP_SAPPHIRE;
+                    }
+                    else if (ancestorTypes.find("gemt") != ancestorTypes.end())
+                    {
+                        flags2 |= ITEM_GROUP_TOPAZ;
+                    }
+                    else if (ancestorTypes.find("gemz") != ancestorTypes.end())
+                    {
+                        flags2 |= ITEM_GROUP_SKULL;
+                    }
+
+                    ItemAttributes *attrs = new ItemAttributes();
+                    attrs->name = (*d)["name"];
+                    attrs->code[0] = (*d)["code"].c_str()[0];
+                    attrs->code[1] = (*d)["code"].c_str()[1];
+                    attrs->code[2] = (*d)["code"].c_str()[2];
+                    attrs->code[3] = 0;
+                    attrs->category = (*d)["type"];
+                    attrs->width = (*d)["invwidth"].at(0) - '0';
+                    attrs->height = (*d)["invheight"].at(0) - '0';
+                    attrs->stackable = stackable;
+                    attrs->useable = useable;
+                    attrs->throwable = throwable;
+                    attrs->itemLevel = 0;
+                    attrs->unusedFlags = 0;
+                    attrs->flags = flags;
+                    attrs->flags2 = flags2;
+                    attrs->qualityLevel = stoi((*d)["level"], nullptr, 10);
+                    attrs->magicLevel = 0;
+                    ItemAttributeMap[(*d)["code"]] = attrs;
+                }
+            }
+        }
+    }
 
 	initialized = true;
 }

--- a/BH/Patch.cpp
+++ b/BH/Patch.cpp
@@ -1,12 +1,10 @@
 #include "Patch.h"
 #include "D2Version.h"
-std::vector<Patch*> Patch::Patches;
 
-Patch::Patch(PatchType type, Dll dll, Offsets offsets, int function, int length) 
+Patch::Patch(PatchType type, Dll dll, Offsets offsets, int function, int length)
 : type(type), dll(dll), offsets(offsets), function(function), length(length) {
 	oldCode = new BYTE[length];
 	injected = false;
-	Patches.push_back(this);
 }
 
 int Patch::GetDllOffset(Dll dll, int offset) {
@@ -61,7 +59,7 @@ bool Patch::Install() {
 
 	//Read the old code to allow proper patch removal
 	ReadProcessMemory(GetCurrentProcess(), (void*)address, oldCode, length, NULL);
-	
+
 	//Set the code with all NOPs by default
 	if (type == 0x68) {
 		memset(code, 0x00, length);

--- a/BH/Patch.h
+++ b/BH/Patch.h
@@ -15,7 +15,6 @@ struct Offsets {
 
 class Patch {
 	private:
-		static std::vector<Patch*> Patches;
 		Dll dll;
 		PatchType type;
 		Offsets offsets;


### PR DESCRIPTION
The `Patches` vector had a global initialization order dependence between it and the `patches` array. Since it's not used the vector was just removed.

The map accesses in `InitializeMPQData` will create a zero-initialized pointer if the key isn't found. Switched to using `find` and checking if the item was found.

Two of the loops in `InitializeMPQData` looked like they were incorrectly nested under `armor` loop. They've been moved out.

`D2COMMON_GetLevel` was using the incorrect ordinal for 1.13d.
